### PR TITLE
Changes necessary to get vs2019 project building again

### DIFF
--- a/source/libsigc++-2.10.2/sigc++/functors/slot.cc
+++ b/source/libsigc++-2.10.2/sigc++/functors/slot.cc
@@ -1,0 +1,25 @@
+// -*- c++ -*-
+/*
+ * Copyright 2002, The libsigc++ Development Team
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ */
+#include <sigc++/functors/slot.h>
+
+namespace sigc {
+
+
+} /* namespace sigc */

--- a/source/libsigc++-2.10.2/sigc++/signal.cc
+++ b/source/libsigc++-2.10.2/sigc++/signal.cc
@@ -1,0 +1,25 @@
+// -*- c++ -*-
+/*
+ * Copyright 2002, The libsigc++ Development Team
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ */
+#include <sigc++/signal.h>
+
+namespace sigc {
+
+
+} /* sigc */

--- a/win32/include/sigc++config.h
+++ b/win32/include/sigc++config.h
@@ -17,7 +17,7 @@
 # if defined(_MSC_VER)
 #  define SIGC_MSC 1
 #  define SIGC_WIN32 1
-#  define SIGC_DLL 1
+//#  define SIGC_DLL 1
 # elif defined(__CYGWIN__)
 #  define SIGC_CONFIGURE 1
 # elif defined(__MINGW32__)


### PR DESCRIPTION
Re-adds the `slot.cc` and `signal.cc` files so we can build a static lib using vs2019.
Comments out the `SIGC_DLL` define 