### PR TITLE
Update sigc++ sigc++config.h and README build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ libsigc++ must be built in both debug and release mode!
    Command Prompt for VS 2019')
 1. Navigate to the pioneer-thirdparty/source/libsigc++-2.10.4/MSVC_NMake
    directory
-1. Run nmake: `nmake /f Makefile.vc CFG=Release`
-1. Copy the dll and lib files to pioneer-thirdparty/win32/*
+1. Run nmake: `nmake /f Makefile.vc CFG=Release PREFIX=install install`
+1. Copy the dll and lib files from install/bin and install/lib to pioneer-thirdparty/win32/*
+
+For new versions of libsigc++, copy the install/include/sigc++-2.0 directory to pioneer-thirdparty/win32/include
+ and (sigc++ source dir)/untracked/MSVC_NMake/sigc++config.h to pioneer-thirdparty/win32/include/sigc++config.h
 

--- a/win32/include/sigc++config.h
+++ b/win32/include/sigc++config.h
@@ -1,4 +1,6 @@
-/* sigc++config.h.  Generated from sigc++config.h.in by configure.  */
+/* This file is part of libsigc++. */
+#ifndef SIGCXXCONFIG_H_INCLUDED
+#define SIGCXXCONFIG_H_INCLUDED
 
 /* Define to omit deprecated API from the library. */
 /* #undef SIGCXX_DISABLE_DEPRECATED */
@@ -6,18 +8,18 @@
 /* Major version number of sigc++. */
 #define SIGCXX_MAJOR_VERSION 2
 
-/* Micro version number of sigc++. */
-#define SIGCXX_MICRO_VERSION 2
-
 /* Minor version number of sigc++. */
 #define SIGCXX_MINOR_VERSION 10
+
+/* Micro version number of sigc++. */
+#define SIGCXX_MICRO_VERSION 4
 
 /* Detect Win32 platform */
 #ifdef _WIN32
 # if defined(_MSC_VER)
 #  define SIGC_MSC 1
 #  define SIGC_WIN32 1
-//#  define SIGC_DLL 1
+#  define SIGC_DLL 1
 # elif defined(__CYGWIN__)
 #  define SIGC_CONFIGURE 1
 # elif defined(__MINGW32__)
@@ -58,17 +60,17 @@
 
 /* does the C++ compiler support the use of a particular specialization when
    calling operator() template methods. */
-# define SIGC_GCC_TEMPLATE_SPECIALIZATION_OPERATOR_OVERLOAD 1
+#define SIGC_GCC_TEMPLATE_SPECIALIZATION_OPERATOR_OVERLOAD
 
 /* Define if the non-standard Sun reverse_iterator must be used. */
-/* # undef SIGC_HAVE_SUN_REVERSE_ITERATOR */
+/* #undef SIGC_HAVE_SUN_REVERSE_ITERATOR */
 
 /* does the C++ compiler support the use of a particular specialization when
    calling operator() template methods omitting the template keyword. */
-# define SIGC_MSVC_TEMPLATE_SPECIALIZATION_OPERATOR_OVERLOAD 1
+#define SIGC_MSVC_TEMPLATE_SPECIALIZATION_OPERATOR_OVERLOAD
 
 /* does the C++ preprocessor support pragma push_macro() and pop_macro(). */
-# define SIGC_PRAGMA_PUSH_POP_MACRO 1
+#define SIGC_PRAGMA_PUSH_POP_MACRO
 
 #endif /* !SIGC_MSC */
 
@@ -83,3 +85,5 @@
 #else /* !SIGC_DLL */
 # define SIGC_API
 #endif /* !SIGC_DLL */
+
+#endif /* !SIGCXXCONFIG_H_INCLUDED */


### PR DESCRIPTION
sigc++config.h isn't generated/installed using the nmake Windows build...but it is present in the source files.

Copied that over and updated instructions for building sigc++ to be a bit more clear.